### PR TITLE
fix: S3에 저장할 이미지 용량 최대 크기 수정 #109

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,10 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
 
 cloud:
   aws:


### PR DESCRIPTION
## #️⃣연관된 이슈

 resolves: #109 

## 📝작업 내용

- S3에 업로드 될 이미지의 허용 크기 설정을 통해서 `org.springframework.web.multipart.MaxUploadSizeExceededException: Maximum upload size exceeded` 에러를 해결했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

