### PR TITLE
feat: 가게 위도 경도 관련 로직 추가 #114

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,8 @@ jobs:
             echo "ACCESS_EXPIRATION_SECONDS=${{ secrets.ACCESS_EXPIRATION_SECONDS }}" >> ./.env
             echo "BUSINESS_SERVICE_KEY=${{ secrets.BUSINESS_SERVICE_KEY }}" >> ./.env
             echo "GOOGLE_FIREBASE_PROJECTID=${{ secrets.GOOGLE_FIREBASE_PROJECTID }}" >> ./.env
+            echo "X_NCP_APIGW_API_KEY_ID=${{ secrets.X_NCP_APIGW_API_KEY_ID }}" >> ./.env
+            echo "X_NCP_APIGW_API_KEY_SECRET=${{ secrets.X_NCP_APIGW_API_KEY_SECRET }}" >> ./.env
 
 
       # 권한 부여 후 gradle build

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -76,6 +76,8 @@ jobs:
             echo "ACCESS_EXPIRATION_SECONDS=${{ secrets.ACCESS_EXPIRATION_SECONDS }}" >> ./.env
             echo "BUSINESS_SERVICE_KEY=${{ secrets.BUSINESS_SERVICE_KEY }}" >> ./.env
             echo "GOOGLE_FIREBASE_PROJECTID=${{ secrets.GOOGLE_FIREBASE_PROJECTID }}" >> ./.env
+            echo "X_NCP_APIGW_API_KEY_ID=${{ secrets.X_NCP_APIGW_API_KEY_ID }}" >> ./.env
+            echo "X_NCP_APIGW_API_KEY_SECRET=${{ secrets.X_NCP_APIGW_API_KEY_SECRET }}" >> ./.env
 
 
       # 권한 부여 후 gradle build

--- a/src/main/java/com/market/core/code/error/GeocodingErrorCode.java
+++ b/src/main/java/com/market/core/code/error/GeocodingErrorCode.java
@@ -1,0 +1,43 @@
+package com.market.core.code.error;
+
+
+import com.market.core.response.ErrorResponse;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Geocoding 에러 코드를 관리하는 enum 클래스입니다.
+ */
+@Getter
+public enum GeocodingErrorCode implements BaseErrorCode {
+
+    INVALID_ADDRESS(400, "유효한 주소가 아닙니다.", HttpStatus.BAD_REQUEST),
+    BAD_REQUEST_EXCEPTION(400, "요청 구문 오류", HttpStatus.BAD_REQUEST),
+    AUTHENTICATION_FAILED(401, "인증 실패", HttpStatus.UNAUTHORIZED),
+    PERMISSION_DENIED(401, "접근 권한 없음", HttpStatus.UNAUTHORIZED),
+    NOT_FOUND_EXCEPTION(404, "서버에서 찾을 수 없음", HttpStatus.NOT_FOUND),
+    REQUEST_ENTITY_TOO_LARGE(413, "요청 크기(10 MB) 초과", HttpStatus.PAYLOAD_TOO_LARGE),
+    QUOTA_EXCEEDED(429, "요청 할당량 초과", HttpStatus.TOO_MANY_REQUESTS),
+    THROTTLE_LIMITED(429, "너무 빠르거나 잦은 요청", HttpStatus.TOO_MANY_REQUESTS),
+    RATE_LIMITED(429, "특정 시간 동안 너무 많은 요청", HttpStatus.TOO_MANY_REQUESTS),
+
+    UNEXPECTED_CLIENT_ERROR(500, "알 수 없는 클라이언트 오류", HttpStatus.INTERNAL_SERVER_ERROR),
+    UNEXPECTED_SERVER_ERROR(500, "알 수 없는 서버 오류", HttpStatus.INTERNAL_SERVER_ERROR),
+    ENDPOINT_ERROR(503, "엔트포인트 오류", HttpStatus.SERVICE_UNAVAILABLE),
+    ENDPOINT_TIMEOUT(504, "엔트포인트 타임아웃", HttpStatus.GATEWAY_TIMEOUT);
+
+    private final int errorCode;
+    private final String errorMessage;
+    private final HttpStatus status;
+
+    GeocodingErrorCode(int errorCode, String errorMessage, HttpStatus status) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.status = status;
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return new ErrorResponse(this.errorCode, this.errorMessage);
+    }
+}

--- a/src/main/java/com/market/core/exception/GeocodingException.java
+++ b/src/main/java/com/market/core/exception/GeocodingException.java
@@ -1,0 +1,19 @@
+package com.market.core.exception;
+
+
+import com.market.core.code.error.BaseErrorCode;
+import lombok.Getter;
+
+/**
+ * Geocoding 관련 예외를 처리하는 클래스입니다.
+ */
+@Getter
+public class GeocodingException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public GeocodingException(BaseErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/market/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/market/core/exception/GlobalExceptionHandler.java
@@ -93,4 +93,14 @@ public class GlobalExceptionHandler {
         BaseErrorCode errorCode = ex.getErrorCode();
         return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getErrorResponse());
     }
+
+    /**
+     * Geocoding 관련 예외 Handler
+     */
+    @ExceptionHandler(GeocodingException.class)
+    protected ResponseEntity<ErrorResponse> handleGeocodingException(GeocodingException ex) {
+        log.error("GeocodingException 발생");
+        BaseErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getErrorResponse());
+    }
 }

--- a/src/main/java/com/market/market/controller/MarketReadController.java
+++ b/src/main/java/com/market/market/controller/MarketReadController.java
@@ -57,10 +57,12 @@ public class MarketReadController {
             @ApiResponse(responseCode = "200", description = "가게 목록 조회 성공")
     })
     @GetMapping()
-    public ResponseEntity<BfResponse<MarketPagingResponse>> findMarketByCursorId(
-            @Parameter(description = "마지막으로 조회한 커서 ID 입니다. 가게 ID 입니다.") @RequestParam("cursorId") Long cursorId,
+    public ResponseEntity<BfResponse<MarketPagingResponse>> findMarketByCursorId (
+            @Parameter(description = "사용자의 위도") @RequestParam("userLatitude") Double userLatitude,
+            @Parameter(description = "사용자의 경도") @RequestParam("userLongitude") Double userLongitude,
+            @Parameter(description = "마지막으로 조회한 커서(가게) ID 입니다. 첫 페이지 요청 시, ID 값은 0 입니다.") @RequestParam("cursorId") Long cursorId,
             @Parameter(description = "페이지의 크기 입니다.") @RequestParam("size") Integer size) {
-        return ResponseEntity.ok(new BfResponse<>(marketPagingService.getMarketByCursorId(cursorId, size)));
+        return ResponseEntity.ok(new BfResponse<>(marketPagingService.getMarketByCursorId(cursorId, size, userLatitude, userLongitude)));
     }
 
     @Operation(

--- a/src/main/java/com/market/market/dto/response/MarketPagingInfoResponse.java
+++ b/src/main/java/com/market/market/dto/response/MarketPagingInfoResponse.java
@@ -26,6 +26,12 @@ public class MarketPagingInfoResponse {
     @Schema(description = "가게 상세 주소입니다.")
     private String specificAddress;
 
+    @Schema(description = "가게 위도")
+    private Double latitude;
+
+    @Schema(description = "가게 경도")
+    private Double longitude;
+
     @Schema(description = "가게 오픈 시간입니다.")
     private String openAt;
 

--- a/src/main/java/com/market/market/dto/server/GeocodingErrorResponse.java
+++ b/src/main/java/com/market/market/dto/server/GeocodingErrorResponse.java
@@ -1,0 +1,20 @@
+package com.market.market.dto.server;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class GeocodingErrorResponse {
+
+    @JsonProperty("error")
+    private Error error;
+
+    @Getter
+    public static class Error {
+        @JsonProperty("errorCode")
+        private String errorCode;
+
+        @JsonProperty("message")
+        private String message;
+    }
+}

--- a/src/main/java/com/market/market/dto/server/MarketPagingInfoDto.java
+++ b/src/main/java/com/market/market/dto/server/MarketPagingInfoDto.java
@@ -26,4 +26,8 @@ public class MarketPagingInfoDto {
 
     private String pickupEndAt;
 
+    private Double latitude;
+
+    private Double longitude;
+
 }

--- a/src/main/java/com/market/market/dto/server/NcpGeocodingInfoDto.java
+++ b/src/main/java/com/market/market/dto/server/NcpGeocodingInfoDto.java
@@ -1,0 +1,76 @@
+package com.market.market.dto.server;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Geocoding 정보 DTO 클래스입니다.
+ */
+@Getter
+public class NcpGeocodingInfoDto {
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("meta")
+    private Object meta;
+
+    @JsonProperty("meta.totalCount")
+    private Integer metaTotalCount;
+
+    @JsonProperty("meta.page")
+    private Integer metaPage;
+
+    @JsonProperty("meta.count")
+    private Integer metaCount;
+
+    @JsonProperty("addresses")
+    List<Address> addresses;
+
+    @JsonProperty("errorMessage")
+    private String errorMessage;
+
+    @Getter
+    public static class Address {
+
+        @JsonProperty("roadAddress")
+        private String roadAddress;
+
+        @JsonProperty("jibunAddress")
+        private String jibunAddress;
+
+        @JsonProperty("englishAddress")
+        private String englishAddress;
+
+        @JsonProperty("addressElements")
+        List<AddressElement> addressElements;
+
+        @JsonProperty("x")
+        private String x;
+
+        @JsonProperty("y")
+        private String y;
+
+        @JsonProperty("distance")
+        private Double distance;
+
+        @Getter
+        public static class AddressElement {
+
+            @JsonProperty("type")
+            private List<String> type;
+
+            @JsonProperty("longName")
+            private String longName;
+
+            @JsonProperty("shortName")
+            private String shortName;
+
+            @JsonProperty("code")
+            private String code;
+        }
+    }
+}

--- a/src/main/java/com/market/market/entity/Market.java
+++ b/src/main/java/com/market/market/entity/Market.java
@@ -11,7 +11,8 @@ import lombok.*;
 @AllArgsConstructor
 public class Market {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -47,6 +48,12 @@ public class Market {
 
     @Column(name = "pickup_end_at")
     private String pickupEndAt;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
 
     public void updateSummary(String summary) {
         this.summary = summary;

--- a/src/main/java/com/market/market/repository/MarketPagingRepository.java
+++ b/src/main/java/com/market/market/repository/MarketPagingRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Slice;
  */
 public interface MarketPagingRepository {
 
-    Slice<MarketPagingInfoDto> findMarketByCursorId(Long cursorId, Integer size);
+    Slice<MarketPagingInfoDto> findMarketByCursorId(Long cursorId, Integer size, Double userLatitude, Double userLongitude);
 
     Slice<MarketPagingInfoDto> findMemberLikeMarketByCursorId(Long memberId, Long cursorId, Integer size);
 }

--- a/src/main/java/com/market/market/repository/MarketPagingRepositoryImpl.java
+++ b/src/main/java/com/market/market/repository/MarketPagingRepositoryImpl.java
@@ -21,7 +21,7 @@ public class MarketPagingRepositoryImpl implements MarketPagingRepository {
     private final EntityManager em;
 
     @Override
-    public Slice<MarketPagingInfoDto> findMarketByCursorId(Long cursorId, Integer size) {
+    public Slice<MarketPagingInfoDto> findMarketByCursorId(Long cursorId, Integer size, Double userLatitude, Double userLongitude) {
 
         List<MarketPagingInfoDto> content =
                 // market 엔티티와 businessInfo 엔티티 조인 후, 데이터 조회
@@ -34,11 +34,18 @@ public class MarketPagingRepositoryImpl implements MarketPagingRepository {
                                 "m.openAt," +
                                 "m.closeAt," +
                                 "m.pickupStartAt," +
-                                "m.pickupEndAt) " +
+                                "m.pickupEndAt," +
+                                "m.latitude," +
+                                "m.longitude) " +
                                 "from Market m " +
                                 "where (:cursorId = 0L or m.id > :cursorId) " +
-                                "order by m.id asc ", MarketPagingInfoDto.class)
+                                "order by " +
+                                "(6371 * " +
+                                "acos(cos(radians(:userLatitude)) * cos(radians(m.latitude)) * cos(radians(m.longitude) - " +
+                                "radians(:userLongitude)) + sin(radians(:userLatitude)) * sin(radians(m.latitude)))) asc ", MarketPagingInfoDto.class)
                         .setParameter("cursorId", cursorId)
+                        .setParameter("userLatitude", userLatitude)
+                        .setParameter("userLongitude", userLongitude)
                         .setMaxResults(size + 1)
                         .getResultList();
 
@@ -59,7 +66,9 @@ public class MarketPagingRepositoryImpl implements MarketPagingRepository {
                                 "m.openAt," +
                                 "m.closeAt," +
                                 "m.pickupStartAt," +
-                                "m.pickupEndAt) " +
+                                "m.pickupEndAt," +
+                                "m.latitude," +
+                                "m.longitude) " +
                                 "from Market m " +
                                 "where (:cursorId = 0L or m.id > :cursorId) " +
                                 "and exists (" +

--- a/src/main/java/com/market/market/service/GeocodingService.java
+++ b/src/main/java/com/market/market/service/GeocodingService.java
@@ -1,0 +1,98 @@
+package com.market.market.service;
+
+
+import com.market.core.exception.GeocodingException;
+import com.market.core.security.dto.jwt.server.NaverErrorResponseDto;
+import com.market.market.dto.server.GeocodingErrorResponse;
+import com.market.market.dto.server.NcpGeocodingInfoDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static com.market.core.code.error.GeocodingErrorCode.*;
+
+/**
+ * Naver Cloud Platform에서 주소 값을 이용해 위도, 경도 값을 추출하는 서비스입니다.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GeocodingService {
+
+    @Value("${x.ncp.apigw.api-key.id}")
+    private String clientKeyId;
+
+    @Value("${x.ncp.apigw.api-key.secret}")
+    private String clientKeySecret;
+
+    private final String GEOCODING_URL = "https://naveropenapi.apigw.ntruss.com/map-geocode/v2/geocode";
+
+    public NcpGeocodingInfoDto getLatitudeAndLongitude(String address) {
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(GEOCODING_URL)
+                .defaultHeader(HttpHeaders.ACCEPT, "application/json")
+                .defaultHeader("X-NCP-APIGW-API-KEY-ID", clientKeyId)
+                .defaultHeader("X-NCP-APIGW-API-KEY", clientKeySecret)
+                .build();
+
+        NcpGeocodingInfoDto ncpGeocodingInfoDto = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("query", address)
+                        .build())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, this::handleClientError)
+                .onStatus(HttpStatusCode::is5xxServerError, this::handleServerError)
+                .bodyToMono(NcpGeocodingInfoDto.class)
+                .block();
+
+        if (ncpGeocodingInfoDto.getAddresses().size() != 1) {
+            throw new GeocodingException(INVALID_ADDRESS);
+        }
+
+        return ncpGeocodingInfoDto;
+    }
+
+    /**
+     * Naver Cloud Platform 클라이언트 오류 처리 메서드
+     */
+    private Mono<? extends Throwable> handleClientError(ClientResponse clientResponse) {
+        int statusCode = clientResponse.statusCode().value();
+        return clientResponse.bodyToMono(GeocodingErrorResponse.class)
+                .flatMap(errorResponse -> {
+                    String errorCode = errorResponse.getError().getErrorCode();
+                    return switch (errorCode) {
+                        case "100" -> Mono.error(new GeocodingException(BAD_REQUEST_EXCEPTION));
+                        case "200" -> Mono.error(new GeocodingException(AUTHENTICATION_FAILED));
+                        case "210" -> Mono.error(new GeocodingException(PERMISSION_DENIED));
+                        case "300" -> Mono.error(new GeocodingException(NOT_FOUND_EXCEPTION));
+                        case "400" -> Mono.error(new GeocodingException(QUOTA_EXCEEDED));
+                        case "410" -> Mono.error(new GeocodingException(THROTTLE_LIMITED));
+                        case "420" -> Mono.error(new GeocodingException(RATE_LIMITED));
+                        case "430" -> Mono.error(new GeocodingException(REQUEST_ENTITY_TOO_LARGE));
+                        default -> Mono.error(new GeocodingException(UNEXPECTED_CLIENT_ERROR));
+                    };
+                });
+    }
+
+    /**
+     * Naver Cloud Platform 서버 오류 처리 메서드
+     */
+    private Mono<? extends Throwable> handleServerError(ClientResponse clientResponse) {
+        return clientResponse.bodyToMono(NaverErrorResponseDto.class)
+                .flatMap(errorResponse -> {
+                    String errorCode = errorResponse.getErrorCode();
+                    return switch (errorCode) {
+                        case "500" -> Mono.error(new GeocodingException(ENDPOINT_ERROR));
+                        case "510" -> Mono.error(new GeocodingException(ENDPOINT_TIMEOUT));
+                        default -> Mono.error(new GeocodingException(UNEXPECTED_SERVER_ERROR));
+                    };
+                });
+    }
+}

--- a/src/main/java/com/market/market/service/MarketCreateService.java
+++ b/src/main/java/com/market/market/service/MarketCreateService.java
@@ -6,6 +6,7 @@ import com.market.core.exception.MarketException;
 import com.market.core.exception.MemberException;
 import com.market.market.dto.request.MarketRegisterRequest;
 import com.market.market.dto.response.RegisterMarketResponse;
+import com.market.market.dto.server.NcpGeocodingInfoDto;
 import com.market.market.entity.Market;
 import com.market.market.repository.MarketRepository;
 import com.market.member.entity.Member;
@@ -23,6 +24,7 @@ public class MarketCreateService {
 
     private final MemberRepository memberRepository;
     private final MarketRepository marketRepository;
+    private final GeocodingService geocodingService;
 
     /**
      * 가게 등록
@@ -38,6 +40,9 @@ public class MarketCreateService {
             throw new MarketException(MarketErrorCode.DUPLICATE_BUSINESS_NUMBER);
         }
 
+        // 주소 값을 이용해, 위도/경도 받아오기
+        NcpGeocodingInfoDto latitudeAndLongitude = geocodingService.getLatitudeAndLongitude(marketRegisterRequest.getAddress());
+
         Market market = Market.builder()
                 .member(member)
                 .marketName(marketRegisterRequest.getName())
@@ -45,6 +50,8 @@ public class MarketCreateService {
                 .address(marketRegisterRequest.getAddress())
                 .specificAddress(marketRegisterRequest.getSpecificAddress())
                 .contactNumber(marketRegisterRequest.getContactNumber())
+                .latitude(Double.parseDouble(latitudeAndLongitude.getAddresses().get(0).getY()))
+                .longitude(Double.parseDouble(latitudeAndLongitude.getAddresses().get(0).getX()))
                 .build();
 
         return RegisterMarketResponse.builder()

--- a/src/main/java/com/market/market/service/MarketPagingService.java
+++ b/src/main/java/com/market/market/service/MarketPagingService.java
@@ -31,12 +31,12 @@ public class MarketPagingService {
      * 커서 기반 페이지네이션을 사용하여 전체 가게 목록을 조회합니다.
      */
     @Transactional(readOnly = true)
-    public MarketPagingResponse getMarketByCursorId(Long cursorId, Integer size) {
+    public MarketPagingResponse getMarketByCursorId(Long cursorId, Integer size, Double userLatitude, Double userLongitude) {
 
         List<MarketPagingInfoResponse> response = new ArrayList<>();
 
         // market 엔티티와 businessInfo 엔티티 조인 후, 데이터 조회
-        Slice<MarketPagingInfoDto> marketList = marketRepository.findMarketByCursorId(cursorId, size);
+        Slice<MarketPagingInfoDto> marketList = marketRepository.findMarketByCursorId(cursorId, size, userLatitude, userLongitude);
 
 
         marketList.getContent().forEach(infoDto -> {
@@ -49,6 +49,8 @@ public class MarketPagingService {
                     .name(infoDto.getMarketName())
                     .address(infoDto.getAddress())
                     .specificAddress(infoDto.getSpecificAddress())
+                    .latitude(infoDto.getLatitude())
+                    .longitude(infoDto.getLongitude())
                     .openAt(infoDto.getOpenAt())
                     .closeAt(infoDto.getCloseAt())
                     .pickupStartAt(infoDto.getPickupStartAt())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,3 +111,11 @@ google:
   firebase:
     secret-key-path: src/main/resources/fcm-secret.json
     projectId: ${GOOGLE_FIREBASE_PROJECTID}
+
+x:
+  ncp:
+    apigw:
+      api-key:
+        id: ${X_NCP_APIGW_API_KEY_ID}
+        secret: ${X_NCP_APIGW_API_KEY_SECRET}
+


### PR DESCRIPTION
## #️⃣연관된 이슈

 resolves: #114 

## 📝작업 내용

- 가게 등록 시, NCP Geocoding API를 사용해서 위도, 경도 값을 받아와 저장하는 로직 추가했습니다.
- 기존에 존재했던 가게 커서기반 페이지네이션 API의 요청 값으로 현재 사용자의 위치(위도,경도)를 추가로 받아오도록 했습니다.
    - 하버사인 공식을 사용해 현재 사용자 위치와 거리가 가까운 순으로 정렬해 페이지네이션하도록 로직을 변경했습니다.
    
- 참고 링크
  -  https://yusang.tistory.com/48
  -  https://api-gov.ncloud-docs.com/docs/ai-naver-mapsgeocoding-geocode

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

