### PR TITLE
feat: Apple OAuth 소셜 로그인 구현 #22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ out/
 ### VS Code ###
 .vscode/
 
-
 ### 루트 경로의 env 파일
 /.env
+
+### Firebase FCM secret key ###
+src/main/resources/fcm-secret.json

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// Nimbus JOSE + JWT
+	implementation 'com.nimbusds:nimbus-jose-jwt:9.31'
+
 	//Database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/market/core/security/config/SecurityConfig.java
+++ b/src/main/java/com/market/core/security/config/SecurityConfig.java
@@ -118,6 +118,7 @@ public class SecurityConfig {
                 antMatcher(GET, "/members/markets"), // 가게 목록 조회
                 antMatcher(GET, "/members/markets/likes"), // 회원 가게 찜 목록 조회
                 antMatcher(POST, "/members/device-token"), // 기기 등록 토큰 저장
+                antMatcher(PATCH, "/members"), // 회원 정보 수정
 
                 // 가게
                 antMatcher(POST, "/markets"), // 가게 등록

--- a/src/main/java/com/market/core/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/market/core/security/handler/CustomAccessDeniedHandler.java
@@ -20,7 +20,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().print("{\"error\": \"접근 거부\", \"message\": \"권한이 없습니다.\"}");
+        response.getWriter().print("{\"errorCode\": \"접근 거부\", \"errorMessage\": \"접근 권한이 없습니다.\"}");
         response.getWriter().flush();
     }
 }

--- a/src/main/java/com/market/core/security/service/oauth/AppleOAuthService.java
+++ b/src/main/java/com/market/core/security/service/oauth/AppleOAuthService.java
@@ -43,8 +43,6 @@ public class AppleOAuthService implements OAuthService {
         return MemberLoginDto.builder()
                 .oauthId(oauthId)
                 .provider(ProviderType.APPLE)
-                .name("default name")
-                .profileImageUrl("default Image")
                 .roles(oAuthLoginRequest.getRoles())
                 .build();
     }

--- a/src/main/java/com/market/core/security/service/oauth/AppleOAuthService.java
+++ b/src/main/java/com/market/core/security/service/oauth/AppleOAuthService.java
@@ -1,0 +1,88 @@
+package com.market.core.security.service.oauth;
+
+import com.market.core.code.error.JwtErrorCode;
+import com.market.core.exception.JwtException;
+import com.market.member.dto.request.OAuthAuthorizationRequest;
+import com.market.member.dto.request.OAuthLoginRequest;
+import com.market.member.dto.server.MemberLoginDto;
+import com.market.member.entity.ProviderType;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+
+/**
+ * Apple OAuth 인증을 통해 액세스 토큰 발급 및 사용자 정보를 조회하는 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class AppleOAuthService implements OAuthService {
+
+    private static final String APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
+
+    /**
+     * Apple OAuth에서는 AccessToken 발급을 직접 처리하지 않으므로 빈 문자열을 반환
+     */
+    @Override
+    public String getAccessToken(OAuthAuthorizationRequest oAuthAuthorizationRequest) {
+        return "";
+    }
+
+    /**
+     * OAuth 제공자에서 사용자 정보를 가져와 MemberLoginDto로 변환
+     */
+    @Override
+    public MemberLoginDto getUserInfo(OAuthLoginRequest oAuthLoginRequest) {
+        JWTClaimsSet claims = verifyAndParseIdToken(oAuthLoginRequest.getAccessToken());
+        String oauthId = claims.getSubject();
+
+        return MemberLoginDto.builder()
+                .oauthId(oauthId)
+                .provider(ProviderType.APPLE)
+                .name("default name")
+                .profileImageUrl("default Image")
+                .roles(oAuthLoginRequest.getRoles())
+                .build();
+    }
+
+    /**
+     * Apple ID Token 검증 및 사용자 정보 파싱
+     */
+    private JWTClaimsSet verifyAndParseIdToken(String idToken) {
+        try {
+            SignedJWT signedJWT = parseJwt(idToken);
+            RSAPublicKey publicKey = getPublicKey(signedJWT.getHeader().getKeyID());
+            verifySignature(signedJWT, publicKey);
+
+            return signedJWT.getJWTClaimsSet();
+        } catch (Exception e) {
+            throw new JwtException(JwtErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    /**
+     * JWT 문자열 파싱
+     */
+    private SignedJWT parseJwt(String idToken) throws Exception {
+        return SignedJWT.parse(idToken);
+    }
+
+    /**
+     * Apple JWKS에서 공개 키 가져오기
+     */
+    private RSAPublicKey getPublicKey(String keyId) throws Exception {
+        JWKSet jwkSet = JWKSet.load(new URL(APPLE_JWKS_URL));
+        return (RSAPublicKey) jwkSet.getKeyByKeyId(keyId).toRSAKey().toPublicKey();
+    }
+
+    /**
+     * JWT 서명을 검증
+     */
+    private void verifySignature(SignedJWT signedJWT, RSAPublicKey publicKey) throws Exception{
+        signedJWT.verify(new com.nimbusds.jose.crypto.RSASSAVerifier(publicKey));
+    }
+}

--- a/src/main/java/com/market/core/security/service/oauth/KakaoOAuthService.java
+++ b/src/main/java/com/market/core/security/service/oauth/KakaoOAuthService.java
@@ -90,7 +90,6 @@ public class KakaoOAuthService implements OAuthService {
                 .oauthId(String.valueOf(userinfo.getOauthId()))
                 .provider(ProviderType.KAKAO)
                 .name(userinfo.getKakaoAccount().getProfile().getName())
-                .profileImageUrl(userinfo.getKakaoAccount().getProfile().getProfileImageUrl())
                 .roles(oAuthLoginRequest.getRoles())
                 .build();
     }

--- a/src/main/java/com/market/core/security/service/oauth/NaverOAuthService.java
+++ b/src/main/java/com/market/core/security/service/oauth/NaverOAuthService.java
@@ -92,7 +92,6 @@ public class NaverOAuthService implements OAuthService {
                 .oauthId(userinfo.getResponse().getOauthId())
                 .provider(ProviderType.NAVER)
                 .name(userinfo.getResponse().getName())
-                .profileImageUrl(userinfo.getResponse().getProfileImageUrl())
                 .roles(oAuthLoginRequest.getRoles())
                 .build();
     }

--- a/src/main/java/com/market/member/controller/MemberController.java
+++ b/src/main/java/com/market/member/controller/MemberController.java
@@ -4,9 +4,12 @@ package com.market.member.controller;
 import com.market.core.code.success.GlobalSuccessCode;
 import com.market.core.response.BfResponse;
 import com.market.core.security.principal.PrincipalDetails;
+import com.market.member.dto.request.MemberUpdateRequest;
 import com.market.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,6 +43,23 @@ public class MemberController {
 
         memberService.saveDeviceToken(Long.parseLong(principalDetails.getUsername()), deviceToken);
 
+        return ResponseEntity.ok(new BfResponse<>(GlobalSuccessCode.SUCCESS));
+    }
+
+    @Operation(
+            summary = "회원 정보 수정",
+            description = "회원 정보를 수정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 정보 수정 성공",
+                    content = @Content(examples = @ExampleObject(value = "{ \"code\": 200, \"message\": \"정상 처리되었습니다.\" }")))
+
+    })
+    @PatchMapping("")
+    public ResponseEntity<BfResponse<Void>> updateMember(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody MemberUpdateRequest memberUpdateRequest) {
+        memberService.updateMember(Long.parseLong(principalDetails.getUsername()), memberUpdateRequest);
         return ResponseEntity.ok(new BfResponse<>(GlobalSuccessCode.SUCCESS));
     }
 }

--- a/src/main/java/com/market/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/market/member/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.market.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+/**
+ * 회원 정보를 업데이트하기 위한 정보를 담는 DTO 클래스입니다.
+ */
+@Getter
+public class MemberUpdateRequest {
+
+    @Schema(description = "회원의 이름", example = "이소은", required = true)
+    private String name;
+}

--- a/src/main/java/com/market/member/dto/server/MemberLoginDto.java
+++ b/src/main/java/com/market/member/dto/server/MemberLoginDto.java
@@ -15,6 +15,5 @@ public class MemberLoginDto {
     private final String oauthId;
     private final ProviderType provider;
     private final String name;
-    private final String profileImageUrl;
     private final RolesType roles;
 }

--- a/src/main/java/com/market/member/entity/Member.java
+++ b/src/main/java/com/market/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.market.member.entity;
 
+import com.market.member.dto.request.MemberUpdateRequest;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -44,5 +45,10 @@ public class Member {
     public void saveDeviceToken(String deviceToken) {
         this.deviceToken = deviceToken;
         this.deviceTokenCreatedAt = LocalDateTime.now();
+    }
+
+    // 회원 가입 시 정보 업데이트
+    public void updateMember(MemberUpdateRequest memberUpdateRequest) {
+        this.name = memberUpdateRequest.getName();
     }
 }

--- a/src/main/java/com/market/member/entity/Member.java
+++ b/src/main/java/com/market/member/entity/Member.java
@@ -31,9 +31,6 @@ public class Member {
     @Column(name = "name")
     private String name; // 사용자 이름
 
-    @Column(name = "profile_image_url")
-    private String profileImageUrl; // 프로필 이미지 URL
-
     @Column(name = "roles")
     @Enumerated(EnumType.STRING)
     private RolesType roles; // 권한
@@ -48,5 +45,4 @@ public class Member {
         this.deviceToken = deviceToken;
         this.deviceTokenCreatedAt = LocalDateTime.now();
     }
-
 }

--- a/src/main/java/com/market/member/service/AuthService.java
+++ b/src/main/java/com/market/member/service/AuthService.java
@@ -105,7 +105,6 @@ public class AuthService {
                 .oauthId(memberLoginDto.getOauthId())
                 .provider(memberLoginDto.getProvider())
                 .name(memberLoginDto.getName())
-                .profileImageUrl(memberLoginDto.getProfileImageUrl())
                 .roles(memberLoginDto.getRoles())
                 .build();
 

--- a/src/main/java/com/market/member/service/AuthService.java
+++ b/src/main/java/com/market/member/service/AuthService.java
@@ -10,6 +10,7 @@ import com.market.core.security.dto.jwt.request.RefreshTokenRequest;
 import com.market.core.security.dto.jwt.response.AccessTokenResponse;
 import com.market.core.security.dto.jwt.response.JwtTokenResponse;
 import com.market.core.security.service.jwt.JwtService;
+import com.market.core.security.service.oauth.AppleOAuthService;
 import com.market.core.security.service.oauth.KakaoOAuthService;
 import com.market.core.security.service.oauth.NaverOAuthService;
 import com.market.core.security.service.oauth.OAuthService;
@@ -36,6 +37,7 @@ public class AuthService {
     private final JwtService jwtService;
     private final KakaoOAuthService kakaoOAuthService;
     private final NaverOAuthService naverOAuthService;
+    private final AppleOAuthService appleOAuthService;
 
     /**
      * Provider 서버에서 AccessToken 발급
@@ -130,7 +132,7 @@ public class AuthService {
         return switch (provider) {
             case NAVER -> naverOAuthService;
             case KAKAO -> kakaoOAuthService;
-            default -> throw new OAuthException(OAuthErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
+            case APPLE -> appleOAuthService;
         };
     }
 }

--- a/src/main/java/com/market/member/service/MemberService.java
+++ b/src/main/java/com/market/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.market.member.service;
 
 import com.market.core.code.error.MemberErrorCode;
 import com.market.core.exception.MemberException;
+import com.market.member.dto.request.MemberUpdateRequest;
 import com.market.member.entity.Member;
 import com.market.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +26,13 @@ public class MemberService {
                 orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER_ID));
 
         member.saveDeviceToken(deviceToken);
+    }
+
+    @Transactional
+    public void updateMember(Long memberId, MemberUpdateRequest memberUpdateRequest) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER_ID));
+
+        member.updateMember(memberUpdateRequest);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

 resolves: #22 

## 📝작업 내용

Apple OAuth 소셜 로그인 구현했습니다.
1. 애플 소셜 로그인 구현
2. 회원 정보 수정 API 개발
3. 회원의 프로필 이미지 속성 제거

## 💬리뷰 요구사항(선택)