### PR TITLE
feat: 상품의 재고 수량 수정 API 개발 #52

### DIFF
--- a/src/main/java/com/market/bucket/service/BucketService.java
+++ b/src/main/java/com/market/bucket/service/BucketService.java
@@ -160,7 +160,7 @@ public class BucketService {
     public void updateBucketProduct(Long memberId, Long productId, Integer count) {
         Bucket bucket = bucketRepository.findByMemberIdAndProductId(memberId, productId).orElseThrow(() -> new BucketException(NOT_FOUND));
 
-        Product product = productRepository.findByProductIdInBucket(productId).orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
+        Product product = productRepository.findByProductIdWithPessimisticWrite(productId).orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
         if (product.getStock() < count) {
             throw new ProductException(STOCK_NOT_ENOUGH);
         }

--- a/src/main/java/com/market/core/code/error/ProductErrorCode.java
+++ b/src/main/java/com/market/core/code/error/ProductErrorCode.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 public enum ProductErrorCode implements BaseErrorCode {
 
     NOT_FOUND_PRODUCT_ID(404, "존재하지 않는 상품입니다.", HttpStatus.NOT_FOUND),
+    UNABLE_TO_UPDATE_STOCK(400, "재고는 음수가 될 수 없습니다.", HttpStatus.BAD_REQUEST),
     STOCK_NOT_ENOUGH(400, "재고가 충분하지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final int errorCode;

--- a/src/main/java/com/market/core/security/config/SecurityConfig.java
+++ b/src/main/java/com/market/core/security/config/SecurityConfig.java
@@ -136,7 +136,8 @@ public class SecurityConfig {
 
                 // 상품
                 antMatcher(DELETE, "/products/{productId}"), // 상품 삭제
-                antMatcher(PATCH, "/products/{productId}"), // 상품 수정
+                antMatcher(PATCH, "/products"), // 상품 재고 수정
+                antMatcher(PUT, "/products"), // 상품 수정
                 antMatcher(POST, "/products"), // 상품 등록
                 antMatcher(POST, "/products/images"), // S3 Bucket에 상품 사진 업로드
                 antMatcher(DELETE, "/products/images"), // S3 Bucket에 상품 사진 삭제

--- a/src/main/java/com/market/product/controller/ProductController.java
+++ b/src/main/java/com/market/product/controller/ProductController.java
@@ -113,7 +113,7 @@ public class ProductController {
     public ResponseEntity<BfResponse<GlobalSuccessCode>> updateProduct(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestBody ProductUpdateRequest productUpdateRequest) {
-        productService.updateProduct(Long.parseLong(principalDetails.getUsername()), productId, productUpdateRequest);
+        productService.updateProduct(Long.parseLong(principalDetails.getUsername()), productUpdateRequest);
         return ResponseEntity.ok(new BfResponse<>(GlobalSuccessCode.SUCCESS));
     }
 

--- a/src/main/java/com/market/product/controller/ProductController.java
+++ b/src/main/java/com/market/product/controller/ProductController.java
@@ -109,7 +109,7 @@ public class ProductController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "상품 수정 성공", useReturnTypeSchema = true),
     })
-    @PatchMapping("/{productId}")
+    @PutMapping()
     public ResponseEntity<BfResponse<GlobalSuccessCode>> updateProduct(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestBody ProductUpdateRequest productUpdateRequest) {

--- a/src/main/java/com/market/product/controller/ProductController.java
+++ b/src/main/java/com/market/product/controller/ProductController.java
@@ -6,6 +6,7 @@ import com.market.core.s3.dto.response.ImageUrlResponse;
 import com.market.core.s3.service.ImageUrlService;
 import com.market.core.security.principal.PrincipalDetails;
 import com.market.product.dto.request.ProductCreateRequest;
+import com.market.product.dto.request.ProductStockUpdateRequest;
 import com.market.product.dto.request.ProductUpdateRequest;
 import com.market.product.dto.response.ProductResponse;
 import com.market.product.service.ProductService;
@@ -111,9 +112,24 @@ public class ProductController {
     @PatchMapping("/{productId}")
     public ResponseEntity<BfResponse<GlobalSuccessCode>> updateProduct(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @PathVariable Long productId,
             @RequestBody ProductUpdateRequest productUpdateRequest) {
         productService.updateProduct(Long.parseLong(principalDetails.getUsername()), productId, productUpdateRequest);
+        return ResponseEntity.ok(new BfResponse<>(GlobalSuccessCode.SUCCESS));
+    }
+
+
+    @Operation(
+            summary = "상품 재고 수정",
+            description = "가게 사장님이 상품의 재고를 수정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상품 재고 수정 성공", useReturnTypeSchema = true),
+    })
+    @PatchMapping()
+    public ResponseEntity<BfResponse<GlobalSuccessCode>> updateProductStock(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody ProductStockUpdateRequest productStockUpdateRequest) {
+        productService.updateProductStock(Long.parseLong(principalDetails.getUsername()), productStockUpdateRequest);
         return ResponseEntity.ok(new BfResponse<>(GlobalSuccessCode.SUCCESS));
     }
 

--- a/src/main/java/com/market/product/dto/request/ProductStockUpdateRequest.java
+++ b/src/main/java/com/market/product/dto/request/ProductStockUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.market.product.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 상품 재고 수정 요청을 위한 DTO 클래스입니다.
+ */
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class ProductStockUpdateRequest {
+
+    @Schema(description = "상품 ID", required = true)
+    Long productId;
+
+    @Schema(description = "변경할 추가 수량 [ +이면 1, -이면 -1]", required = true)
+    Integer count;
+}

--- a/src/main/java/com/market/product/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/com/market/product/dto/request/ProductUpdateRequest.java
@@ -18,6 +18,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProductUpdateRequest {
 
+    @Schema(description = "상품 ID", required = true)
+    Long productId;
+
     @Schema(description = "상품 이미지", example = "https://.../ab123...456.png", required = true)
     private String productImage;
 

--- a/src/main/java/com/market/product/entity/Product.java
+++ b/src/main/java/com/market/product/entity/Product.java
@@ -54,4 +54,8 @@ public class Product {
         this.discountRate = productUpdateRequest.getDiscountRate();
         this.stock = productUpdateRequest.getStock();
     }
+
+    public void updateProductStock(Integer count) {
+        this.stock += count;
+    }
 }

--- a/src/main/java/com/market/product/repository/ProductRepository.java
+++ b/src/main/java/com/market/product/repository/ProductRepository.java
@@ -23,5 +23,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Lock(value = LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({@QueryHint(name = "product lock timeout in bucket", value = "3000")}) // 락 휙득을 위해 3초까지 대기
     @Query("select p from Product p where p.id = :productId")
-    Optional<Product> findByProductIdInBucket(@Param("productId") Long productId);
+    Optional<Product> findByProductIdWithPessimisticWrite(@Param("productId") Long productId);
 }

--- a/src/main/java/com/market/product/service/ProductService.java
+++ b/src/main/java/com/market/product/service/ProductService.java
@@ -124,8 +124,8 @@ public class ProductService {
      * 상품을 수정합니다.
      */
     @Transactional
-    public void updateProduct(Long memberId, Long productId, ProductUpdateRequest productUpdateRequest) {
-        Product product = productRepository.findById(productId)
+    public void updateProduct(Long memberId, ProductUpdateRequest productUpdateRequest) {
+        Product product = productRepository.findByProductIdWithPessimisticWrite(productUpdateRequest.getProductId())
                 .orElseThrow(() -> new ProductException(ProductErrorCode.NOT_FOUND_PRODUCT_ID));
 
         Market market = marketRepository.findMarketByProductId(productId)

--- a/src/main/java/com/market/product/service/ProductService.java
+++ b/src/main/java/com/market/product/service/ProductService.java
@@ -128,7 +128,7 @@ public class ProductService {
         Product product = productRepository.findByProductIdWithPessimisticWrite(productUpdateRequest.getProductId())
                 .orElseThrow(() -> new ProductException(ProductErrorCode.NOT_FOUND_PRODUCT_ID));
 
-        Market market = marketRepository.findMarketByProductId(productId)
+        Market market = marketRepository.findMarketByProductId(productUpdateRequest.getProductId())
                 .orElseThrow(() -> new MarketException(MarketErrorCode.NOT_FOUND_MARKET_ID));
 
         // 가게 소유자가 맞는지 확인
@@ -140,7 +140,7 @@ public class ProductService {
         }
 
         // 기존 product tag 삭제
-        productTagRepository.deleteAllByProductId(productId);
+        productTagRepository.deleteAllByProductId(productUpdateRequest.getProductId());
 
 
         List<String> productTagNames = productUpdateRequest.getProductTags();

--- a/src/main/java/com/market/product/service/ProductService.java
+++ b/src/main/java/com/market/product/service/ProductService.java
@@ -14,6 +14,7 @@ import com.market.market.repository.TagRepository;
 import com.market.member.entity.Member;
 import com.market.member.repository.MemberRepository;
 import com.market.product.dto.request.ProductCreateRequest;
+import com.market.product.dto.request.ProductStockUpdateRequest;
 import com.market.product.dto.request.ProductUpdateRequest;
 import com.market.product.dto.response.ProductResponse;
 import com.market.product.entity.Product;
@@ -28,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.market.core.code.error.ProductErrorCode.UNABLE_TO_UPDATE_STOCK;
 
 @Service
 @RequiredArgsConstructor
@@ -131,6 +134,11 @@ public class ProductService {
         // 가게 소유자가 맞는지 확인
         verifyOwnerOfMarket(memberId, market.getId());
 
+        // 재고가 음수가 되는 것을 방지
+        if (productUpdateRequest.getStock() < 0) {
+            throw new ProductException(UNABLE_TO_UPDATE_STOCK);
+        }
+
         // 기존 product tag 삭제
         productTagRepository.deleteAllByProductId(productId);
 
@@ -171,6 +179,29 @@ public class ProductService {
 
         // 재고 업데이트 알림 전송
         sendProductUpdatedAlarm(market);
+    }
+
+    /**
+     * 상품의 재고를 수정합니다.
+     */
+    @Transactional
+    public void updateProductStock(Long memberId, ProductStockUpdateRequest productStockUpdateRequest) {
+        Product product = productRepository.findByProductIdWithPessimisticWrite(productStockUpdateRequest.getProductId())
+                .orElseThrow(() -> new ProductException(ProductErrorCode.NOT_FOUND_PRODUCT_ID));
+
+        Market market = marketRepository.findMarketByProductId(productStockUpdateRequest.getProductId())
+                .orElseThrow(() -> new MarketException(MarketErrorCode.NOT_FOUND_MARKET_ID));
+
+        // 가게 소유자가 맞는지 확인
+        verifyOwnerOfMarket(memberId, market.getId());
+
+        // 재고가 음수가 되는 것을 방지
+        if (product.getStock() + productStockUpdateRequest.getCount() < 0) {
+            throw new ProductException(UNABLE_TO_UPDATE_STOCK);
+        }
+
+        product.updateProductStock(productStockUpdateRequest.getCount());
+
     }
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈

 resolves: #52 

## 📝작업 내용

- 사장님의 상품 재고 수정 API를 추가했습니다.
- 상품 수정 API의 Http 메소드를 변경했습니다.
- **상품 수정 시, 데이터베이스에 락을 설정해 동시성을 제어했습니다.**

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
