### PR TITLE
feat: 주문하기 API 추가 #45

### DIFF
--- a/src/main/java/com/market/bucket/dto/server/BucketProductDto.java
+++ b/src/main/java/com/market/bucket/dto/server/BucketProductDto.java
@@ -24,8 +24,11 @@ public class BucketProductDto {
     @Schema(description = "상품 원가")
     private Integer originPrice;
 
-    @Schema(description = "상품 할인가")
+    @Schema(description = "상품 할인가(실 판매가)")
     private Integer discountPrice;
+
+    @Schema(description = "상품 재고")
+    private Integer stock;
 
     @Schema(description = "장바구니 속 상품 갯수")
     private Integer count;

--- a/src/main/java/com/market/bucket/repository/BucketRepository.java
+++ b/src/main/java/com/market/bucket/repository/BucketRepository.java
@@ -2,6 +2,8 @@ package com.market.bucket.repository;
 
 import com.market.bucket.dto.server.BucketProductDto;
 import com.market.bucket.entity.Bucket;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
@@ -17,12 +19,15 @@ public interface BucketRepository extends JpaRepository<Bucket, Long> {
      * @param memberId bucket, product 테이블을 조인 후, memberId 값으로 필터링
      * @return
      */
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "product lock timeout in bucket", value = "3000")}) // 락 휙득을 위해 3초까지 대기
     @Query("select new com.market.bucket.dto.server.BucketProductDto(" +
             "product.id," +
             "product.name," +
             "product.productImage," +
             "product.originPrice," +
             "product.discountPrice," +
+            "product.stock," +
             "bucket.count) " +
             "from Bucket bucket " +
             "inner join Product product on bucket.product.id = product.id " +

--- a/src/main/java/com/market/core/code/error/OrdersErrorCode.java
+++ b/src/main/java/com/market/core/code/error/OrdersErrorCode.java
@@ -13,7 +13,9 @@ public enum OrdersErrorCode implements BaseErrorCode {
 
     // 404 NOT_FOUND
     NOT_FOUND_ORDERS_ID(404, "존재하지 않는 주문번호입니다.", HttpStatus.NOT_FOUND),
-    NOT_FOUND_ORDERS_STATUS(404, "존재하지 않는 주문 상태입니다.", HttpStatus.NOT_FOUND);
+    NOT_FOUND_ORDERS_STATUS(404, "존재하지 않는 주문 상태입니다.", HttpStatus.NOT_FOUND),
+    ORDERS_CREATE_METHOD_NOT_ALLOWED(405, "재고가 부족해 주문이 불가능합니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    BUCKET_ITEM_NOT_FOUND(500, "장바구니 상품이 없어 주문 생성 불가", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/com/market/core/security/config/SecurityConfig.java
+++ b/src/main/java/com/market/core/security/config/SecurityConfig.java
@@ -143,6 +143,7 @@ public class SecurityConfig {
                 antMatcher(DELETE, "/products/images"), // S3 Bucket에 상품 사진 삭제
 
                 // 주문
+                antMatcher(POST, "/orders"), // 주문 생성
                 antMatcher(GET, "/orders/{orderId}") // 주문 상세 조회
         );
 
@@ -181,6 +182,7 @@ public class SecurityConfig {
 
                 // 가게
                 antMatcher(GET, "/markets"), // 전체 가게 목록 페이징 조회
+
 
                 // 상품
                 antMatcher(GET, "/products") // 상품 목록 조회

--- a/src/main/java/com/market/orders/controller/OrdersCreateController.java
+++ b/src/main/java/com/market/orders/controller/OrdersCreateController.java
@@ -1,0 +1,46 @@
+package com.market.orders.controller;
+
+
+import com.market.core.response.BfResponse;
+import com.market.core.security.principal.PrincipalDetails;
+import com.market.orders.dto.request.OrdersCreateRequestDto;
+import com.market.orders.dto.response.OrdersCreateResponseDto;
+import com.market.orders.service.OrdersCreateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 주문 Create 관련 API controller 입니다.
+ */
+@RestController
+@RequestMapping("orders")
+@RequiredArgsConstructor
+@Tag(name = "주문 CREATE", description = "주문 CREATE 관련 API")
+public class OrdersCreateController {
+
+    private final OrdersCreateService ordersCreateService;
+
+    @Operation(
+            summary = "주문 생성",
+            description = "주문 생성입니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "주문 생성 성공", useReturnTypeSchema = true)
+    })
+    @PostMapping
+    public ResponseEntity<BfResponse<OrdersCreateResponseDto>> createOrders(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @Valid @RequestBody OrdersCreateRequestDto ordersCreateRequestDto) {
+        return ResponseEntity.ok(new BfResponse<>(ordersCreateService.createOrders(Long.parseLong(principalDetails.getUsername()), ordersCreateRequestDto)));
+    }
+}

--- a/src/main/java/com/market/orders/dto/request/OrdersCreateRequestDto.java
+++ b/src/main/java/com/market/orders/dto/request/OrdersCreateRequestDto.java
@@ -1,0 +1,23 @@
+package com.market.orders.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import javax.annotation.Nullable;
+import java.time.LocalDateTime;
+
+/**
+ * 주문 등록 요청을 위한 DTO 클래스입니다.
+ */
+@Getter
+public class OrdersCreateRequestDto {
+
+    @NotNull
+    @Schema(description = "픽업 희망 시간", required = true)
+    private LocalDateTime pickupReservedAt;
+
+    @Nullable
+    @Schema(description = "고객 요청 사항")
+    private String customerRequest;
+}

--- a/src/main/java/com/market/orders/dto/response/MemberOrdersResponse.java
+++ b/src/main/java/com/market/orders/dto/response/MemberOrdersResponse.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class MemberOrdersResponse {
 
     @Schema(description = "주문 ID")
-    private Long ordersId;
+    private String ordersId;
 
     @Schema(description = "가게 ID")
     private Long marketId;

--- a/src/main/java/com/market/orders/dto/response/OrdersCreateResponseDto.java
+++ b/src/main/java/com/market/orders/dto/response/OrdersCreateResponseDto.java
@@ -1,0 +1,24 @@
+package com.market.orders.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 주문 생성 응답 DTO 입니다.
+ */
+@Getter
+@Builder
+@Schema(description = "주문 생성 응답 DTO 입니다.")
+public class OrdersCreateResponseDto {
+
+    @Schema(description = "주문 ID")
+    private String ordersId;
+
+    @Schema(description = "주문 이름", example = "생수 외 1건")
+    private String ordersName;
+
+    @Schema(description = "주문 금액")
+    private Integer amount;
+}

--- a/src/main/java/com/market/orders/dto/response/OrdersResponse.java
+++ b/src/main/java/com/market/orders/dto/response/OrdersResponse.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class OrdersResponse {
 
     @Schema(description = "주문 ID")
-    private Long id;
+    private String id;
 
     @Schema(description = "주문 접수된 시각")
     private LocalDateTime createdAt;

--- a/src/main/java/com/market/orders/entity/Orders.java
+++ b/src/main/java/com/market/orders/entity/Orders.java
@@ -15,8 +15,7 @@ import java.time.LocalDateTime;
 public class Orders {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/market/orders/entity/Orders.java
+++ b/src/main/java/com/market/orders/entity/Orders.java
@@ -45,6 +45,9 @@ public class Orders {
     @Column(name = "customer_request")
     private String customerRequest;
 
+    @Column(name = "orders_name")
+    private String ordersName;
+
     public void updateOrdersStatus(OrdersStatus ordersStatus) {
         this.ordersStatus = ordersStatus;
     }

--- a/src/main/java/com/market/orders/entity/OrdersStatus.java
+++ b/src/main/java/com/market/orders/entity/OrdersStatus.java
@@ -10,7 +10,8 @@ import static com.market.core.code.error.OrdersErrorCode.NOT_FOUND_ORDERS_STATUS
 
 @Getter
 public enum OrdersStatus {
-    ORDERED,// 주문 접수
+    IN_PROGRESS, // 결제 승인 이전의 주문 상태
+    ORDERED, // 주문 접수
     ACCEPTED, // 주문 수락
     PICKEDUP, // 픽업 완료
     CANCELED, // 주문 취소

--- a/src/main/java/com/market/orders/repository/OrdersProductRepository.java
+++ b/src/main/java/com/market/orders/repository/OrdersProductRepository.java
@@ -1,0 +1,7 @@
+package com.market.orders.repository;
+
+import com.market.orders.entity.OrdersProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrdersProductRepository extends JpaRepository<OrdersProduct, Long> {
+}

--- a/src/main/java/com/market/orders/repository/OrdersRepository.java
+++ b/src/main/java/com/market/orders/repository/OrdersRepository.java
@@ -33,7 +33,7 @@ public interface OrdersRepository extends JpaRepository<Orders, Long> {
             "op.count) " +
             "from OrdersProduct op inner join Product p on op.product.id = p.id " +
             "where op.orders.id = :ordersId")
-    List<OrdersProductsDto> getOrdersProductsDtoByOrdersId(@Param("ordersId") Long ordersId);
+    List<OrdersProductsDto> getOrdersProductsDtoByOrdersId(@Param("ordersId") String ordersId);
 
     @Query("select o from Orders o join fetch o.member")
     Optional<Orders> getOrdersByOrdersId(@Param("ordersId") Long ordersId);

--- a/src/main/java/com/market/orders/service/OrdersCreateService.java
+++ b/src/main/java/com/market/orders/service/OrdersCreateService.java
@@ -1,0 +1,112 @@
+package com.market.orders.service;
+
+import com.market.bucket.dto.server.BucketProductDto;
+import com.market.bucket.repository.BucketRepository;
+import com.market.core.exception.MarketException;
+import com.market.core.exception.MemberException;
+import com.market.core.exception.OrdersException;
+import com.market.core.exception.ProductException;
+import com.market.market.entity.Market;
+import com.market.market.repository.MarketRepository;
+import com.market.member.entity.Member;
+import com.market.member.repository.MemberRepository;
+import com.market.orders.dto.request.OrdersCreateRequestDto;
+import com.market.orders.dto.response.OrdersCreateResponseDto;
+import com.market.orders.entity.Orders;
+import com.market.orders.entity.OrdersProduct;
+import com.market.orders.entity.OrdersStatus;
+import com.market.orders.repository.OrdersProductRepository;
+import com.market.orders.repository.OrdersRepository;
+import com.market.product.entity.Product;
+import com.market.product.repository.ProductRepository;
+import com.market.utils.random.OrdersIdUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.market.core.code.error.MarketErrorCode.NOT_FOUND_MARKET_ID;
+import static com.market.core.code.error.MemberErrorCode.NOT_FOUND_MEMBER_ID;
+import static com.market.core.code.error.OrdersErrorCode.BUCKET_ITEM_NOT_FOUND;
+import static com.market.core.code.error.OrdersErrorCode.ORDERS_CREATE_METHOD_NOT_ALLOWED;
+import static com.market.core.code.error.ProductErrorCode.NOT_FOUND_PRODUCT_ID;
+
+
+@Service
+@RequiredArgsConstructor
+public class OrdersCreateService {
+
+    private final MemberRepository memberRepository;
+    private final BucketRepository bucketRepository;
+    private final MarketRepository marketRepository;
+    private final ProductRepository productRepository;
+    private final OrdersProductRepository ordersProductRepository;
+    private final OrdersRepository ordersRepository;
+
+    private final OrdersIdUtils ordersIdUtils;
+
+    @Transactional
+    public OrdersCreateResponseDto createOrders(Long memberId, OrdersCreateRequestDto ordersCreateRequestDto) {
+
+        List<BucketProductDto> bucketProducts = bucketRepository.findAllBucketProductByMemberId(memberId);
+
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ID));
+        Market market = marketRepository.findMarketByProductId(bucketProducts.get(0).getId())
+                .orElseThrow(() -> new MarketException(NOT_FOUND_MARKET_ID));
+
+        if (bucketProducts.isEmpty()) {
+            throw new OrdersException(BUCKET_ITEM_NOT_FOUND);
+        }
+
+        int totalPrice = 0;
+
+        // 상품 재고와 장바구니 갯수 비교
+        for (BucketProductDto bucketProductDto : bucketProducts) {
+            if (bucketProductDto.getStock() < bucketProductDto.getCount()) {
+                throw new OrdersException(ORDERS_CREATE_METHOD_NOT_ALLOWED);
+            }
+
+            totalPrice += bucketProductDto.getDiscountPrice() * bucketProductDto.getCount();
+        }
+
+        String ordersName = bucketProducts.size() > 1 ?
+                bucketProducts.get(0).getName() + " 외 " + (bucketProducts.size() - 1) : bucketProducts.get(0).getName();
+
+        // 주문 생성
+        Orders orders = Orders.builder()
+                .id(ordersIdUtils.generateOrdersId())
+                .member(member)
+                .market(market)
+                .createdAt(LocalDateTime.now())
+                .pickupReservedAt(ordersCreateRequestDto.getPickupReservedAt())
+                .ordersPrice(totalPrice)
+                .doneAt(null)
+                .ordersStatus(OrdersStatus.IN_PROGRESS)
+                .customerRequest(ordersCreateRequestDto.getCustomerRequest())
+                .ordersName(ordersName)
+                .build();
+
+        ordersRepository.save(orders);
+
+        // 주문 상품 생성
+        for (BucketProductDto bucketProductDto : bucketProducts) {
+
+            Product product = productRepository.findById(bucketProductDto.getId())
+                    .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
+
+            ordersProductRepository.save(OrdersProduct.builder()
+                    .orders(orders)
+                    .product(product)
+                    .count(bucketProductDto.getCount())
+                    .build());
+        }
+
+        return OrdersCreateResponseDto.builder()
+                .ordersId(orders.getId())
+                .ordersName(orders.getOrdersName())
+                .amount(orders.getOrdersPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/market/utils/random/OrdersIdUtils.java
+++ b/src/main/java/com/market/utils/random/OrdersIdUtils.java
@@ -1,0 +1,25 @@
+package com.market.utils.random;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+public class OrdersIdUtils {
+
+    private static String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    private static Random random = new Random();
+
+    public String generateOrdersId() {
+
+        int length = random.nextInt(59) + 6; // 6 ~ 64 자리의 랜덤 길이 추출
+
+        // 문자열 생성
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none # 추후 none 변경
+      ddl-auto: create # 추후 none 변경
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## #️⃣연관된 이슈

 resolves: #45 

## 📝작업 내용

 - 토스 페이먼츠 결제 승인 API 호출 전에, 주문 튜플을 생성하는 API 입니다.
   -  주문 튜플을 생성하고 주문 ID, 주문 이름, 결제될 금액을 반환합니다.
   -  클라이언트는 해당 정보를 기반으로, 결제 요청 및 인증을 수행합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

