### PR TITLE
feat: 회원 프로필 조회 API 추가 #128

### DIFF
--- a/src/main/java/com/market/core/security/config/SecurityConfig.java
+++ b/src/main/java/com/market/core/security/config/SecurityConfig.java
@@ -117,8 +117,8 @@ public class SecurityConfig {
                 antMatcher(GET, "/members/orders"), // 회원 주문 내역
                 antMatcher(GET, "/members/markets"), // 가게 목록 조회
                 antMatcher(GET, "/members/markets/likes"), // 회원 가게 찜 목록 조회
-                antMatcher(POST, "/members/device-token"), // 기기 등록 토큰 저장
                 antMatcher(PATCH, "/members"), // 회원 정보 수정
+                antMatcher(GET, "/members/profiles"), // 회원 정보 수정
 
                 // 가게
                 antMatcher(POST, "/markets"), // 가게 등록
@@ -177,13 +177,15 @@ public class SecurityConfig {
                 // AWS Health Check
                 antMatcher(GET, "utils/health"),
 
+                // 회원
+                antMatcher(POST, "/members/device-token"), // 기기 등록 토큰 저장
+
                 // 토큰
                 antMatcher(POST, "/auth/accessToken"), // OAuth AccessToken 발급
                 antMatcher(POST, "/auth/login"), // OAuth 로그인
 
                 // 가게
                 antMatcher(GET, "/markets"), // 전체 가게 목록 페이징 조회
-
 
                 // 상품
                 antMatcher(GET, "/products") // 상품 목록 조회

--- a/src/main/java/com/market/member/controller/MemberController.java
+++ b/src/main/java/com/market/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.market.core.code.success.GlobalSuccessCode;
 import com.market.core.response.BfResponse;
 import com.market.core.security.principal.PrincipalDetails;
 import com.market.member.dto.request.MemberUpdateRequest;
+import com.market.member.dto.response.ProfileReadResponseDto;
 import com.market.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -61,5 +62,18 @@ public class MemberController {
             @RequestBody MemberUpdateRequest memberUpdateRequest) {
         memberService.updateMember(Long.parseLong(principalDetails.getUsername()), memberUpdateRequest);
         return ResponseEntity.ok(new BfResponse<>(GlobalSuccessCode.SUCCESS));
+    }
+
+    @Operation(
+            summary = "회원 프로필 조회",
+            description = "회원 프로필 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 프로필 조회 성공", useReturnTypeSchema = true)
+    })
+    @GetMapping("/profiles")
+    public ResponseEntity<BfResponse<ProfileReadResponseDto>> readMemberProfile(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ResponseEntity.ok(new BfResponse<>(memberService.readMemberProfile(Long.parseLong(principalDetails.getUsername()))));
     }
 }

--- a/src/main/java/com/market/member/dto/response/ProfileReadResponseDto.java
+++ b/src/main/java/com/market/member/dto/response/ProfileReadResponseDto.java
@@ -1,0 +1,23 @@
+package com.market.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 프로필 조회 응답 DTO 입니다.
+ */
+@Getter
+@Builder
+@Schema(description = "프로필 조회 응답 DTO 입니다.")
+public class ProfileReadResponseDto {
+
+    @Schema(description = "회원 ID")
+    private Long id;
+
+    @Schema(description = "회원 닉네임")
+    private String name;
+
+    @Schema(description = "소셜 정보. [ NAVER, KAKAO, APPLE]")
+    private String provider;
+}

--- a/src/main/java/com/market/member/service/MemberService.java
+++ b/src/main/java/com/market/member/service/MemberService.java
@@ -1,14 +1,15 @@
 package com.market.member.service;
 
-
-import com.market.core.code.error.MemberErrorCode;
 import com.market.core.exception.MemberException;
 import com.market.member.dto.request.MemberUpdateRequest;
+import com.market.member.dto.response.ProfileReadResponseDto;
 import com.market.member.entity.Member;
 import com.market.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.market.core.code.error.MemberErrorCode.NOT_FOUND_MEMBER_ID;
 
 /**
  * 회원 서비스 클래스입니다.
@@ -23,7 +24,7 @@ public class MemberService {
     public void saveDeviceToken(Long memberId, String deviceToken) {
 
         Member member = memberRepository.findById(memberId).
-                orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER_ID));
+                orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ID));
 
         member.saveDeviceToken(deviceToken);
     }
@@ -31,8 +32,19 @@ public class MemberService {
     @Transactional
     public void updateMember(Long memberId, MemberUpdateRequest memberUpdateRequest) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND_MEMBER_ID));
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ID));
 
         member.updateMember(memberUpdateRequest);
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileReadResponseDto readMemberProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ID));
+
+        return ProfileReadResponseDto.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .provider(member.getProvider().name())
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

 resolves: #128 

## 📝작업 내용

- 회원 프로필 조회 기능 추가했습니다.
- 회원 기기 토큰 저장 API의 인가를 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

**- 모든 소셜 서버에서 회원 프로필 이미지를 받아 올 수 있나요?**